### PR TITLE
Add missing fields to Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,7 @@
 name = "UnitParser"
+uuid = "4c23ceaa-6d37-4888-96ed-67eddcae2acd"
+authors = ["Benoît Richard <benoit.richard@desy.de>"]
+version = "0.1.0"
 
 [deps]
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"


### PR DESCRIPTION
I tried to install this package via `]add add https://github.com/Kolaru/UnitsParser.jl.git` on Julia v1.6.0-beta1, but got the following error:

```
ERROR: expected a `uuid` entry in project file at `/tmp/jl_qqEEB8/Project.toml
```

So I added the missing fields, and Pkg is happy. I just generated the `uuid` using `UUIDs.uuid4()`.